### PR TITLE
Fix footer position, allowing clicks on social links

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -669,6 +669,7 @@ margin on the iframe, cause it breaks stuff. */
     border-bottom: #EBF2F6 1px solid;
     word-break: break-word;
     hyphens: auto;
+    overflow: hidden;
 }
 
 /* Add a little circle in the middle of the border-bottom on our .post


### PR DESCRIPTION
Currently the article.body layout ignored `position:float` content.

Setting `overflow: hidden` on .post will force article.body's height to include `position:float` elements

Before
![Screen Shot 2021-03-03 at 3 09 45 pm](https://user-images.githubusercontent.com/346545/109751532-c62d5200-7c32-11eb-970e-a1b7d9006108.png)

After
![Screen Shot 2021-03-03 at 3 10 25 pm](https://user-images.githubusercontent.com/346545/109751543-ccbbc980-7c32-11eb-8f42-8d0fd0541497.png)
